### PR TITLE
Fix pre-commit installation

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Install pre-commit
         run: |
-          pip install pre-commit
+          pipx install pre-commit
 
       - name: Run pre-commit
         run: |


### PR DESCRIPTION
In newer Ubuntu versions installing globally with pip is prohibited. But because pre-commit is an application, we can switch to pipx.